### PR TITLE
Fix the capture issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can download Hearthdash from the [releases](https://github.com/postcasio/hea
 ### Requirements
 
 * OS X, Windows
-* nodejs v0.10
+* nodejs v0.12
 * coffee-script
 * protobuf
 
@@ -34,10 +34,18 @@ Homebrew is the best way to install Node and protobufs on OS X:
 
 ### Building
 
-    cd tools
+    npm install
+    cd capture
+    npm install
+    cd ../tools
     npm install
     coffee build.coffee --card-xml-path=<path>
 
-Where `path` is the path to the `cardxml0.unity3d` file in the Hearthstone Data directory.
+Where `path` is the path to the `cardxml0.unity3d` file in the Hearthstone Data directory. If you don't set this paramater, default value is /Applications/Hearthstone/Data/OSX/cardxml0.unity3d
 
 Hearthdash should now be in the `build` directory.
+
+You probably need run with sudo to make sure it can capture network packs.
+
+    sudo build/Hearthdash.app/Contents/MacOS/Atom
+

--- a/capture/package.json
+++ b/capture/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cap": "0.0.10",
+    "cap": "0.0.15",
     "minimist": "^1.1.0",
     "node-protobuf": "^1.2.1"
   }

--- a/src/app/game-manager.coffee
+++ b/src/app/game-manager.coffee
@@ -229,6 +229,7 @@ module.exports = class GameManager
 					size = @gameView.opponentHandView.addCard entity.name
 
 	onCreateGame: (message) ->
+		@reset()#need call this, otherwise the entities is null
 
 	getEntity: (entity, update=true) ->
 		if @entities[entity.id]

--- a/tools/extract-card-data.coffee
+++ b/tools/extract-card-data.coffee
@@ -19,13 +19,13 @@ xml2js.parseString cards, (err, result) ->
 			id: card.$.CardID
 
 		for tag in card.Tag
-			switch tag.$.name
-				when 'CardName'
+			switch tag.$.enumID
+				when '185'
 					data.name = tag._
-				when 'CardTextInHand'
-					data.text = tag.$.value
+				when '184'
+					data.text = tag._
 				else
-					data[tag.$.name.toLowerCase()] = tag.$.value
+					data[tag.$.enumID] = tag.$.value
 
 		cardData[data.id] = data
 


### PR DESCRIPTION
upgrade the cap version. Call reset() for onCreateGame. Update README.

The tool now works fine on Hearthstone 2.6.0.8834